### PR TITLE
Déplacement de la balise <mco:useLimitation>

### DIFF
--- a/src/main/plugin/iso19115-3.2018/process/mw-constraints-cleanup-nosplit.xsl
+++ b/src/main/plugin/iso19115-3.2018/process/mw-constraints-cleanup-nosplit.xsl
@@ -119,14 +119,14 @@ WHERE data LIKE '%Reporting INSPIRE<%'
             </mri:resourceConstraints>
             <mri:resourceConstraints>
               <mco:MD_LegalConstraints>
+                <mco:useLimitation>
+                  <gco:CharacterString>Conditions d'utilisation spécifiques</gco:CharacterString>
+                </mco:useLimitation>    
                 <mco:useConstraints>
                   <mco:MD_RestrictionCode
                     codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"
                     codeListValue="otherRestrictions"/>
                 </mco:useConstraints>
-                <mco:useLimitation>
-                  <gco:CharacterString>Conditions d'utilisation spécifiques</gco:CharacterString>
-                </mco:useLimitation>
                 <mco:otherConstraints>
                   <gco:CharacterString>Les conditions d'utilisation du service sont régies par les Conditions d’accès et d’utilisation des services web géographiques de visualisation du Service public de Wallonie consultables à l'adresse https://geoportail.wallonie.be/files/documents/ConditionsSPW/LicServicesSPW.pdf.</gco:CharacterString>
                 </mco:otherConstraints>


### PR DESCRIPTION
Pour éviter l'erreur de schéma dans l'outil de validation INSPIRE. Déplacement de la balise <mco:useLimitation> en première position dans le deuxième bloc resourceConstraint.